### PR TITLE
feat: inline module specifier

### DIFF
--- a/packages/htms-js/src/stream/helpers.ts
+++ b/packages/htms-js/src/stream/helpers.ts
@@ -4,7 +4,7 @@ import { ReadableStream } from 'node:stream/web';
 
 import { ModuleResolver, type ModuleResolverOptions } from '../resolvers/index.js';
 import { createHtmsResolver, type Resolver } from './resolver.js';
-import { createHtmsSerializer } from './serializer.js';
+import { createHtmsSerializer, type HtmsSerializerOptions } from './serializer.js';
 import { createHtmsTokenizer } from './tokenizer.js';
 
 export type IOStream = ReadableStream<string>;
@@ -17,30 +17,50 @@ export function createFileStream(filePath: string): IOStream {
   return ReadableStream.from(fs.createReadStream(filePath, { encoding: 'utf8' }));
 }
 
-export function createHtmsPipeline(inputStream: IOStream, resolver: Resolver): IOStream {
+export interface HtmsPipelineOptions {
+  serializerOptions?: HtmsSerializerOptions | undefined;
+}
+
+export function createHtmsPipeline(
+  inputStream: IOStream,
+  resolver: Resolver,
+  options?: HtmsPipelineOptions | undefined,
+): IOStream {
   return inputStream
     .pipeThrough(createHtmsTokenizer())
     .pipeThrough(createHtmsResolver(resolver))
-    .pipeThrough(createHtmsSerializer());
+    .pipeThrough(createHtmsSerializer(options?.serializerOptions));
 }
 
-export function createHtmsStringPipeline(rawHtml: string, resolver: Resolver): IOStream {
-  return createHtmsPipeline(createStringStream(rawHtml), resolver);
+export function createHtmsStringPipeline(
+  rawHtml: string,
+  resolver: Resolver,
+  options?: HtmsPipelineOptions | undefined,
+): IOStream {
+  return createHtmsPipeline(createStringStream(rawHtml), resolver, options);
 }
 
-export function createHtmsFilePipeline(filePath: string, resolver: Resolver): IOStream {
-  return createHtmsPipeline(createFileStream(filePath), resolver);
+export function createHtmsFilePipeline(
+  filePath: string,
+  resolver: Resolver,
+  options?: HtmsPipelineOptions | undefined,
+): IOStream {
+  return createHtmsPipeline(createFileStream(filePath), resolver, options);
 }
 
 export type ModuleExtension = 'js' | 'cjs' | 'mjs' | 'ts' | 'cts' | 'mts';
 
-export interface ModulePipelineOptions extends ModuleResolverOptions {
+export interface ModulePipelineOptions extends HtmsPipelineOptions, ModuleResolverOptions {
   specifier?: string | undefined;
   extension?: ModuleExtension | undefined;
 }
 
-export function createHtmsStringModulePipeline(rawHtml: string, moduleSpecifier: string): IOStream {
-  return createHtmsStringPipeline(rawHtml, new ModuleResolver(moduleSpecifier));
+export function createHtmsStringModulePipeline(
+  rawHtml: string,
+  moduleSpecifier: string,
+  options?: HtmsPipelineOptions | undefined,
+): IOStream {
+  return createHtmsStringPipeline(rawHtml, new ModuleResolver(moduleSpecifier), options);
 }
 
 function changeExtension(filePath: string, extension: ModuleExtension): string {
@@ -58,5 +78,5 @@ export function createModuleResolver(filePath: string, options?: ModulePipelineO
 }
 
 export function createHtmsFileModulePipeline(filePath: string, options?: ModulePipelineOptions | undefined): IOStream {
-  return createHtmsFilePipeline(filePath, createModuleResolver(filePath, options));
+  return createHtmsFilePipeline(filePath, createModuleResolver(filePath, options), options);
 }

--- a/packages/htms-js/src/stream/resolver.ts
+++ b/packages/htms-js/src/stream/resolver.ts
@@ -29,22 +29,14 @@ export type ResolverStream = TransformStream<Token, ResolverToken>;
 export function createHtmsResolver(resolver: Resolver): ResolverStream {
   const taskTokens: TaskToken[] = [];
 
-  let specifier: string | undefined;
-
   return new TransformStream({
     async transform(token, controller) {
       controller.enqueue(token);
 
-      if (token.type === 'htmsStartModule') {
-        specifier = token.specifier;
-      } else if (token.type === 'htmsEndModule') {
-        specifier = undefined;
-      }
-
       if (token.type === 'htmsTag') {
         try {
           const taskInfo = token.taskInfo;
-          const task = await resolver.resolve(taskInfo, token.specifier ?? specifier);
+          const task = await resolver.resolve(taskInfo, token.specifier);
 
           if (typeof task === 'function') {
             taskTokens.push(createTaskToken(taskInfo, task));

--- a/packages/htms-js/src/stream/tokenizer.ts
+++ b/packages/htms-js/src/stream/tokenizer.ts
@@ -5,12 +5,12 @@ import { RewritingStream } from 'parse5-html-rewriting-stream';
 
 export type StartTag = Parameters<RewritingStream['emitStartTag']>[0];
 export type EndTag = Parameters<RewritingStream['emitEndTag']>[0];
-export type Attribute = StartTag['attrs'][number];
 
-export type TokenType = 'startTag' | 'endTag' | 'rawHtml' | 'htmsTag';
+export type TokenType = 'startTag' | 'endTag' | 'rawHtml' | 'htmsTag' | 'htmsStartModule' | 'htmsEndModule';
 
 export interface BaseToken {
   type: TokenType;
+  tag: StartTag | EndTag;
   html: string;
 }
 
@@ -24,7 +24,7 @@ export interface EndTagToken extends BaseToken {
   tag: EndTag;
 }
 
-export interface RawHtmlToken extends BaseToken {
+export interface RawHtmlToken extends Omit<BaseToken, 'tag'> {
   type: 'rawHtml';
 }
 
@@ -37,34 +37,86 @@ export interface HtmsTagToken extends BaseToken {
   type: 'htmsTag';
   tag: StartTag;
   taskInfo: TaskInfo;
+  specifier?: string | undefined;
 }
 
-export type Token = StartTagToken | EndTagToken | HtmsTagToken | RawHtmlToken;
+export interface HtmsStartModuleToken extends BaseToken {
+  type: 'htmsStartModule';
+  tag: StartTag;
+  specifier: string;
+}
 
-export function findAttribute(tag: StartTag, name: string): Attribute | undefined {
-  return tag.attrs.find((attribute) => attribute.name === name);
+export interface HtmsEndModuleToken extends BaseToken {
+  type: 'htmsEndModule';
+  tag: EndTag;
+  specifier: string;
+}
+
+export type StartToken = StartTagToken | HtmsTagToken | HtmsStartModuleToken;
+export type EndToken = EndTagToken | HtmsEndModuleToken;
+export type Token = StartToken | EndToken | RawHtmlToken;
+
+export function mapAttributes(tag: StartTag): Map<string, string> {
+  return new Map(tag.attrs.map(({ name, value }) => [name, value]));
 }
 
 export type TokenizerStream = TransformStream<string | Buffer, Token>;
 
 export function createHtmsTokenizer(): TokenizerStream {
   const rewriter = new RewritingStream();
+  const tokenStack: StartToken[] = [];
 
   return new TransformStream({
     start(controller) {
-      rewriter.on('startTag', (tag, html) => {
-        const htmsAttribute = findAttribute(tag, 'data-htms');
+      function pushStartToken(token: StartToken) {
+        controller.enqueue(token);
 
-        if (htmsAttribute === undefined) {
-          controller.enqueue({ type: 'startTag', tag, html });
-        } else {
-          const taskInfo = { name: htmsAttribute.value, uuid: randomUUID() };
-
-          controller.enqueue({ type: 'htmsTag', tag, html, taskInfo });
+        if (!token.tag.selfClosing) {
+          tokenStack.push(token);
         }
+      }
+
+      rewriter.on('startTag', (tag, html) => {
+        const attributes = mapAttributes(tag);
+
+        const dataHtms = attributes.get('data-htms');
+        const htmsModule = attributes.get('data-htms-module');
+
+        if (dataHtms) {
+          const taskInfo: TaskInfo = { name: dataHtms, uuid: randomUUID() };
+
+          pushStartToken({ type: 'htmsTag', tag, html, taskInfo, specifier: htmsModule });
+          return;
+        }
+
+        if (htmsModule) {
+          pushStartToken({ type: 'htmsStartModule', tag, html, specifier: htmsModule });
+          return;
+        }
+
+        pushStartToken({ type: 'startTag', tag, html });
       });
 
       rewriter.on('endTag', (tag, html) => {
+        const lastToken = tokenStack.pop();
+
+        if (!lastToken) {
+          controller.error(`Missing open tag: '${html}' at ${formatCodeLocation(tag)}`);
+          return;
+        }
+
+        if (lastToken.tag.tagName !== tag.tagName) {
+          controller.error(
+            `Mismatch close tag: expected '</${lastToken.tag.tagName}>', got '${html}'  at ${formatCodeLocation(tag)}`,
+          );
+          return;
+        }
+
+        if (lastToken.type === 'htmsStartModule') {
+          controller.enqueue({ type: 'htmsEndModule', tag, html, specifier: lastToken.specifier });
+          return;
+        }
+
         controller.enqueue({ type: 'endTag', tag, html });
       });
 
@@ -79,8 +131,23 @@ export function createHtmsTokenizer(): TokenizerStream {
     transform(chunk) {
       rewriter.write(chunk);
     },
-    flush() {
+    flush(controller) {
+      if (tokenStack.length > 0) {
+        const lines = [
+          `Missing close tag(s): ${tokenStack.length}`,
+          tokenStack.map(({ tag }) => `- <${tag.tagName}> opened at ${formatCodeLocation(tag)}`),
+        ];
+
+        controller.error(lines.join('\n'));
+      }
+
       rewriter.end();
     },
   });
+}
+
+function formatCodeLocation(tag: StartTag | EndTag): string {
+  const { startLine = 0, startCol = 0 } = tag.sourceCodeLocation ?? {};
+
+  return `[${startLine}:${startCol}]`;
 }

--- a/packages/htms-js/tests/fixtures/html/simple.html
+++ b/packages/htms-js/tests/fixtures/html/simple.html
@@ -12,7 +12,7 @@
     </section>
     <section>
       <h1>articles</h1>
-      <div data-htms="getArticles">loading...</div>
+      <div data-htms="getArticles" data-htms-module="simple.js">loading...</div>
     </section>
     <footer>static footer</footer>
   </body>

--- a/packages/htms-js/tests/module-resolver.test.ts
+++ b/packages/htms-js/tests/module-resolver.test.ts
@@ -9,12 +9,6 @@ const fixturesDirectory = path.resolve(import.meta.dirname, 'fixtures', 'tasks')
 const uuidMock = 'uuid-test-0000-0000-mock';
 
 describe('ModuleResolver', () => {
-  it('should throws in the constructor when the module path does not exist', () => {
-    expect(() => new ModuleResolver('does-not-exist.mjs', { basePath: fixturesDirectory })).toThrow(
-      `[htms] module not found 'does-not-exist.mjs' at '${fixturesDirectory}'`,
-    );
-  });
-
   it('should rejects task when the function is missing', async () => {
     const file = path.resolve(fixturesDirectory, 'empty.ts');
     const resolver = new ModuleResolver(file);
@@ -22,7 +16,7 @@ describe('ModuleResolver', () => {
 
     const task = await resolver.resolve(info);
 
-    await expect(task()).rejects.toThrow(`[htms] task function 'notThere' not found in '${file}'`);
+    await expect(task()).rejects.toThrow(`Task function 'notThere' not found in '${file}'`);
   });
 
   it('should resolves a named exported function', async () => {

--- a/packages/htms-js/tests/resolver.test.ts
+++ b/packages/htms-js/tests/resolver.test.ts
@@ -50,7 +50,7 @@ describe('createHtmsResolver', () => {
     await expect(articlesTaskToken.task()).resolves.toBe('task done: getArticles');
   });
 
-  it('should ...', async () => {
+  it('should throw error when the task throw an error', async () => {
     mockRandomUUIDIncrement();
 
     const input = createFileStream(simpleHtmlFixture);

--- a/packages/htms-js/tests/serializer.test.ts
+++ b/packages/htms-js/tests/serializer.test.ts
@@ -2,7 +2,7 @@ import './fixtures/crypto.mock.js';
 
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   createFileStream,
@@ -102,6 +102,7 @@ describe('createHtmsSerializer', () => {
   });
 
   it('should serialize a simple html file with [data-htms] attribute', async () => {
+    const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(vi.fn());
     mockRandomUUIDIncrement();
 
     const html = '<div data-htms="goodTask"/>\n<div data-htms="badTask"/>\n';
@@ -110,7 +111,7 @@ describe('createHtmsSerializer', () => {
       resolve(info) {
         return () => {
           if (info.name === 'badTask') {
-            throw new Error(`Oupsy! Something wrong append in this task: ${info.name}`);
+            throw new Error(`Oupsy! Something wrong appended in this task: ${info.name}`);
           }
 
           return Promise.resolve(`good task done: ${info.name}`);
@@ -121,12 +122,78 @@ describe('createHtmsSerializer', () => {
     const output = input
       .pipeThrough(createHtmsTokenizer())
       .pipeThrough(createHtmsResolver(resolver))
-      .pipeThrough(createHtmsSerializer());
+      .pipeThrough(createHtmsSerializer({ debug: false }));
 
-    expect(await collectString(output)).toMatchInlineSnapshot(`
+    const outputString = await collectString(output);
+
+    expect(consoleErrorMock).toHaveBeenCalledExactlyOnceWith(
+      'Unhandled Task Error',
+      expect.objectContaining({
+        message: 'Oupsy! Something wrong appended in this task: badTask',
+      }),
+    );
+
+    expect(outputString).toMatchInlineSnapshot(`
       "<div data-htms="goodTask" data-htms-uuid="uuid-test-0000-0000-mock"/>
       <div data-htms="badTask" data-htms-uuid="uuid-test-0000-0001-mock"/>
-      <htms-chunk uuid="uuid-test-0000-0001-mock"></htms-chunk>
+      <htms-chunk uuid="uuid-test-0000-0001-mock">
+      <div data-htms-error>
+      <h2>Unhandled Task Error</h2>
+      <p>Oops! We hit an unexpected error here.</p>
+      <p>Please contact the site administrator if the issue persists.</p>
+      </div>
+      </htms-chunk>
+      <htms-chunk uuid="uuid-test-0000-0000-mock">good task done: goodTask</htms-chunk>
+      "
+    `);
+  });
+
+  it('should serialize a simple html file with [data-htms] attribute (debug = true)', async () => {
+    const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+    mockRandomUUIDIncrement();
+
+    const html = '<div data-htms="goodTask"/>\n<div data-htms="badTask"/>\n';
+    const input = createStringStream(html);
+    const resolver: Resolver = {
+      resolve(info) {
+        return () => {
+          if (info.name === 'badTask') {
+            throw new Error(`Oupsy! Something wrong appended in this task: ${info.name}`);
+          }
+
+          return Promise.resolve(`good task done: ${info.name}`);
+        };
+      },
+    };
+
+    const output = input
+      .pipeThrough(createHtmsTokenizer())
+      .pipeThrough(createHtmsResolver(resolver))
+      .pipeThrough(createHtmsSerializer({ debug: true }));
+
+    const outputString = await collectString(output);
+
+    expect(consoleErrorMock).toHaveBeenCalledExactlyOnceWith(
+      'Unhandled Task Error',
+      expect.objectContaining({
+        message: 'Oupsy! Something wrong appended in this task: badTask',
+      }),
+    );
+
+    expect(outputString).toMatchInlineSnapshot(`
+      "<div data-htms="goodTask" data-htms-uuid="uuid-test-0000-0000-mock"/>
+      <div data-htms="badTask" data-htms-uuid="uuid-test-0000-0001-mock"/>
+      <htms-chunk uuid="uuid-test-0000-0001-mock">
+      <div data-htms-error>
+      <h2>Unhandled Task Error</h2>
+      <pre>error: Oupsy! Something wrong appended in this task: badTask
+      token: {
+        "type": "task",
+        "name": "badTask",
+        "uuid": "uuid-test-0000-0001-mock"
+      }</pre>
+      </div>
+      </htms-chunk>
       <htms-chunk uuid="uuid-test-0000-0000-mock">good task done: goodTask</htms-chunk>
       "
     `);

--- a/packages/htms-js/tests/tokenizer.test.ts
+++ b/packages/htms-js/tests/tokenizer.test.ts
@@ -46,6 +46,7 @@ describe('createHtmsTokenizer', () => {
       html: '<div data-htms="taskNameTest">',
       tag: { tagName: 'div' },
       type: 'htmsTag',
+      specifier: undefined,
       taskInfo: {
         uuid: uuidMock,
         name: 'taskNameTest',
@@ -60,5 +61,95 @@ describe('createHtmsTokenizer', () => {
       tag: { tagName: 'div' },
       type: 'endTag',
     });
+  });
+
+  it('should tokenize a simple html string with [data-htms] and [data-htms-module] attribute', async () => {
+    const uuidMock = 'uuid-test-0000-0000-mock';
+    mockRandomUUIDOnce(uuidMock);
+
+    const html = '<div data-htms="taskNameTest" data-htms-module="../path/to/module.js">...</div>';
+    const input = createStringStream(html);
+
+    const output = input.pipeThrough(createHtmsTokenizer());
+    const tokens = await collect(output);
+
+    expect(tokens).toHaveLength(3);
+    expect(tokens[0]).toMatchObject({
+      html: '<div data-htms="taskNameTest" data-htms-module="../path/to/module.js">',
+      tag: { tagName: 'div' },
+      type: 'htmsTag',
+      specifier: '../path/to/module.js',
+      taskInfo: {
+        uuid: uuidMock,
+        name: 'taskNameTest',
+      },
+    });
+  });
+
+  it('should tokenize a simple html string with only [data-htms-module] attribute', async () => {
+    const uuidMock = 'uuid-test-0000-0000-mock';
+    mockRandomUUIDOnce(uuidMock);
+
+    const html = '<div data-htms-module="../path/to/module-only.js">...</div>';
+    const input = createStringStream(html);
+
+    const output = input.pipeThrough(createHtmsTokenizer());
+    const tokens = await collect(output);
+
+    expect(tokens).toHaveLength(3);
+    expect(tokens[0]).toMatchObject({
+      html: '<div data-htms-module="../path/to/module-only.js">',
+      tag: { tagName: 'div' },
+      type: 'htmsStartModule',
+      specifier: '../path/to/module-only.js',
+    });
+    expect(tokens[1]).toMatchObject({
+      html: '...',
+      type: 'rawHtml',
+    });
+    expect(tokens[2]).toMatchObject({
+      html: '</div>',
+      tag: { tagName: 'div' },
+      type: 'htmsEndModule',
+      specifier: '../path/to/module-only.js',
+    });
+  });
+
+  it('should throws error if missing end tag', async () => {
+    const uuidMock = 'uuid-test-0000-0000-mock';
+    mockRandomUUIDOnce(uuidMock);
+
+    const html = '<div data-htms-module="../path/to/module-only.js">';
+    const input = createStringStream(html);
+
+    const output = input.pipeThrough(createHtmsTokenizer());
+
+    await expect(collect(output)).rejects.toThrowError('Missing close tag(s): 1');
+  });
+
+  it('should throws error if missing start tag', async () => {
+    const uuidMock = 'uuid-test-0000-0000-mock';
+    mockRandomUUIDOnce(uuidMock);
+
+    const html = '<span>hello</span></span>';
+    const input = createStringStream(html);
+
+    const output = input.pipeThrough(createHtmsTokenizer());
+
+    await expect(collect(output)).rejects.toThrowError("Missing open tag: '</span>' at [1:19]");
+  });
+
+  it('should throws error if start/end tag mismatch', async () => {
+    const uuidMock = 'uuid-test-0000-0000-mock';
+    mockRandomUUIDOnce(uuidMock);
+
+    const html = '<span>hello</div>';
+    const input = createStringStream(html);
+
+    const output = input.pipeThrough(createHtmsTokenizer());
+
+    await expect(collect(output)).rejects.toThrowError(
+      "Mismatch close tag: expected '</span>', got '</div>'  at [1:12]",
+    );
   });
 });


### PR DESCRIPTION
Add inline module specifier for fine grained tasks

```html
<section data-htms-module="module-a.js">
  <div data-htms="taskA">loading task A from 'module-a.js'...</div>
  <div data-htms="taskA" data-htms-module="module-b.js">loading task A from 'module-b.js'...</div>

  <div data-htms-module="module-b.js">
    <div data-htms="taskA">loading task A from 'module-b.js'...</div>
    <div data-htms="taskA" data-htms-module="module-a.js">loading task A from 'module-a.js'...</div>
  </div>

  <div data-htms="taskB">loading task B from 'module-a.js'...</div>
  <div data-htms="taskB" data-htms-module="module-b.js">loading task B from 'module-b.js'...</div>
</section>
```
