### PR TITLE
refactor!:  replace `data-htms-params` with `data-htms-value`

### DIFF
--- a/packages/fastify-htms/readme.md
+++ b/packages/fastify-htms/readme.md
@@ -85,48 +85,60 @@ HTMS supports scoped modules, meaning tasks can resolve from different modules d
 
 This makes it easier to compose and reuse modules without conflicts.
 
-## Task parameters (`data-htms-args`)
+## Task value (`data-htms-value`)
 
-Pass parameters to tasks via a JSON/JSON5 array stored in the `data-htms-args` attribute.
+`data-htms-value` passes **one argument** to the task.
+When present, the value is parsed as **JSON5** and given to the task as its **first parameter**.
+If the attribute is **omitted**, the task receives `undefined`.
 
-- Accepts either a **JSON/JSON5 array** (recommended) or a **comma-separated list** without brackets.
-- You can also pass a **single value**; it is treated as the first argument (equivalent to wrapping it in `[...]`).
-- Supports: single or double quotes, unquoted object keys, trailing commas, comments.
-- **Not supported:** `undefined`, functions, arbitrary JS expressions. Use `null` when you need to indicate “no value.”
+- Accepted: `undefined`, `null`, booleans, numbers, strings, arrays, objects (JSON5: single quotes, unquoted keys, comments, trailing commas).
+- Not accepted: functions, arbitrary JS expressions.
+- Need multiple pieces of data? Pack them into **one** object or array.
 
-**HTML examples**
+### HTML examples
 
 ```html
-<!-- JSON/JSON5 array -->
-<div data-htms="renderUserCard" data-htms-args='[12345, "en-GB", { showBadges: true, theme: "compact" }]' />
+<!-- attribute omitted → value = undefined -->
+<div data-htms="loadDefaults"></div>
 
-<!-- Comma-separated list (equivalent to an array) -->
-<div data-htms="renderFeed" data-htms-args="12345, { limit: 10, cursor: null }" />
+<!-- primitive values -->
+<div data-htms="loadDefaults" data-htms-value="null"></div>
+<div data-htms="loadProfile" data-htms-value="true"></div>
+<div data-htms="loadUser" data-htms-value="12345"></div>
+<div data-htms="loadByName" data-htms-value="'john-doe'"></div>
 
-<!-- Single value (first argument only) -->
-<div data-htms="loadProfile" data-htms-args="12345" />
+<!-- object / array (JSON5) -->
+<div data-htms="loadFeed" data-htms-value="{ theme: 'compact', limit: 10 }"></div>
+<div data-htms="renderOffer" data-htms-value="[42, { theme: 'compact' }]"></div>
 ```
 
-**Task examples**
+### Task signatures (TypeScript examples)
 
-```js
-// page-module.js
-export async function renderUserCard(userId, locale, opts) {
-  // userId === 12345
-  // locale === "en-GB"
-  // opts === { showBadges: true, theme: "compact" }
-  return `<div class="user-card">User #${userId}</div>`;
+```ts
+export async function loadDefaults(value: undefined | null) {}
+export async function loadProfile(value: boolean) {}
+export async function loadUser(value: number) {}
+export async function loadByName(value: string) {}
+
+export async function loadFeed(value: { theme: string; limit: number }) {
+  // value.theme === 'compact'
+  // value.limit === 10
 }
 
-export async function renderFeed(userId, page) {
-  // page === { limit: 10, cursor: null }
-  return `<ul class="feed">...</ul>`;
-}
-
-export async function loadProfile(userId) {
-  return `<div class="profile">Profile of ${userId}</div>`;
+export async function renderOffer(value: [number, { theme: string }]) {
+  const [offerId, options] = value;
+  // offerId === 42
+  // options.theme === 'compact'
 }
 ```
+
+### Tips
+
+- **Keep it serializable.** Only data you could express in JSON5 should go here.
+- **Prefer objects** when the meaning of fields matters: `{ id, page, sort }` is clearer than `[id, page, sort]`.
+- **Strings must be quoted.** Use JSON5 single quotes in HTML to stay readable.
+- **Validate inside the task.** Treat the value as untrusted input.
+- **One argument by design.** If you need several inputs, bundle them: `(value)` where `value` is an object/array.
 
 ## Commit behavior (`data-htms-commit`)
 

--- a/packages/htms-js/readme.md
+++ b/packages/htms-js/readme.md
@@ -146,48 +146,60 @@ HTMS supports scoped modules, meaning tasks can resolve from different modules d
 
 This makes it easier to compose and reuse modules without conflicts.
 
-## Task parameters (`data-htms-args`)
+## Task value (`data-htms-value`)
 
-Pass parameters to tasks via a JSON/JSON5 array stored in the `data-htms-args` attribute.
+`data-htms-value` passes **one argument** to the task.
+When present, the value is parsed as **JSON5** and given to the task as its **first parameter**.
+If the attribute is **omitted**, the task receives `undefined`.
 
-- Accepts either a **JSON/JSON5 array** (recommended) or a **comma-separated list** without brackets.
-- You can also pass a **single value**; it is treated as the first argument (equivalent to wrapping it in `[...]`).
-- Supports: single or double quotes, unquoted object keys, trailing commas, comments.
-- **Not supported:** `undefined`, functions, arbitrary JS expressions. Use `null` when you need to indicate “no value.”
+- Accepted: `undefined`, `null`, booleans, numbers, strings, arrays, objects (JSON5: single quotes, unquoted keys, comments, trailing commas).
+- Not accepted: functions, arbitrary JS expressions.
+- Need multiple pieces of data? Pack them into **one** object or array.
 
-**HTML examples**
+### HTML examples
 
 ```html
-<!-- JSON/JSON5 array -->
-<div data-htms="renderUserCard" data-htms-args='[12345, "en-GB", { showBadges: true, theme: "compact" }]' />
+<!-- attribute omitted → value = undefined -->
+<div data-htms="loadDefaults"></div>
 
-<!-- Comma-separated list (equivalent to an array) -->
-<div data-htms="renderFeed" data-htms-args="12345, { limit: 10, cursor: null }" />
+<!-- primitive values -->
+<div data-htms="loadDefaults" data-htms-value="null"></div>
+<div data-htms="loadProfile" data-htms-value="true"></div>
+<div data-htms="loadUser" data-htms-value="12345"></div>
+<div data-htms="loadByName" data-htms-value="'john-doe'"></div>
 
-<!-- Single value (first argument only) -->
-<div data-htms="loadProfile" data-htms-args="12345" />
+<!-- object / array (JSON5) -->
+<div data-htms="loadFeed" data-htms-value="{ theme: 'compact', limit: 10 }"></div>
+<div data-htms="renderOffer" data-htms-value="[42, { theme: 'compact' }]"></div>
 ```
 
-**Task examples**
+### Task signatures (TypeScript examples)
 
-```js
-// page-module.js
-export async function renderUserCard(userId, locale, opts) {
-  // userId === 12345
-  // locale === "en-GB"
-  // opts === { showBadges: true, theme: "compact" }
-  return `<div class="user-card">User #${userId}</div>`;
+```ts
+export async function loadDefaults(value: undefined | null) {}
+export async function loadProfile(value: boolean) {}
+export async function loadUser(value: number) {}
+export async function loadByName(value: string) {}
+
+export async function loadFeed(value: { theme: string; limit: number }) {
+  // value.theme === 'compact'
+  // value.limit === 10
 }
 
-export async function renderFeed(userId, page) {
-  // page === { limit: 10, cursor: null }
-  return `<ul class="feed">...</ul>`;
-}
-
-export async function loadProfile(userId) {
-  return `<div class="profile">Profile of ${userId}</div>`;
+export async function renderOffer(value: [number, { theme: string }]) {
+  const [offerId, options] = value;
+  // offerId === 42
+  // options.theme === 'compact'
 }
 ```
+
+### Tips
+
+- **Keep it serializable.** Only data you could express in JSON5 should go here.
+- **Prefer objects** when the meaning of fields matters: `{ id, page, sort }` is clearer than `[id, page, sort]`.
+- **Strings must be quoted.** Use JSON5 single quotes in HTML to stay readable.
+- **Validate inside the task.** Treat the value as untrusted input.
+- **One argument by design.** If you need several inputs, bundle them: `(value)` where `value` is an object/array.
 
 ## Commit behavior (`data-htms-commit`)
 

--- a/packages/htms-js/src/stream/resolver.ts
+++ b/packages/htms-js/src/stream/resolver.ts
@@ -2,7 +2,7 @@ import { TransformStream } from 'node:stream/web';
 
 import type { TaskInfo, Token } from './tokenizer.js';
 
-export type Task = (...parameters: unknown[]) => PromiseLike<string>;
+export type Task<Value = unknown> = (value?: Value) => PromiseLike<string>;
 
 export interface TaskToken extends TaskInfo {
   type: 'task';

--- a/packages/htms-js/src/stream/serializer.ts
+++ b/packages/htms-js/src/stream/serializer.ts
@@ -49,7 +49,7 @@ function processEndTag(token: EndToken, controller: Controller): void {
 
 async function runTask(token: TaskToken, controller: Controller, debug: boolean): Promise<void> {
   try {
-    const output = await token.task(...token.parameters);
+    const output = await token.task(token.value);
 
     controller.enqueue(`<htms-chunk uuid="${token.uuid}" commit="${token.commit}">${output}</htms-chunk>\n`);
   } catch (error_) {

--- a/packages/htms-js/src/stream/tokenizer.ts
+++ b/packages/htms-js/src/stream/tokenizer.ts
@@ -54,7 +54,7 @@ export interface TaskInfo {
   name: string;
   uuid: string;
   commit: Commit;
-  parameters: unknown[];
+  value: unknown;
 }
 
 export interface HtmsTagToken extends BaseToken {
@@ -110,18 +110,18 @@ export function createHtmsTokenizer(): TokenizerStream {
         if (dataHtms) {
           try {
             const htmsCommit = attributes.get('data-htms-commit');
-            const htmsParameters = attributes.get('data-htms-params');
+            const htmsValue = attributes.get('data-htms-value');
 
             const taskInfo: TaskInfo = {
               name: dataHtms,
               uuid: randomUUID(),
               commit: parseCommit(htmsCommit),
-              parameters: parseParameters(htmsParameters),
+              value: parseValue(htmsValue),
             };
 
             pushStartToken({ type: 'htmsTag', tag, html, taskInfo, specifier: htmsModule ?? scopes.at(-1) });
           } catch (error) {
-            controller.error(`Failed to parse [data-htms-params] at ${formatCodeLocation(tag)}: ${error}`);
+            controller.error(`Failed to parse [data-htms-value] at ${formatCodeLocation(tag)}: ${error}`);
           }
 
           return;
@@ -192,14 +192,12 @@ function formatCodeLocation(tag: StartTag | EndTag): string {
   return `[${startLine}:${startCol}]`;
 }
 
-function parseParameters(input: string | undefined): unknown[] {
+function parseValue(input: string | undefined): unknown {
   const trimmedInput = input?.trim();
 
-  if (!trimmedInput || trimmedInput === '') {
-    return [];
+  if (!trimmedInput || trimmedInput === '' || trimmedInput === 'undefined') {
+    return undefined;
   }
 
-  const wrappedInput = trimmedInput.startsWith('[') ? trimmedInput : `[${trimmedInput}]`;
-
-  return JSON5.parse(wrappedInput);
+  return JSON5.parse(trimmedInput);
 }

--- a/packages/htms-js/tests/module-resolver.test.ts
+++ b/packages/htms-js/tests/module-resolver.test.ts
@@ -12,7 +12,7 @@ describe('ModuleResolver', () => {
   it('should rejects task when the function is missing', async () => {
     const file = path.resolve(fixturesDirectory, 'empty.ts');
     const resolver = new ModuleResolver(file);
-    const info: TaskInfo = { name: 'notThere', uuid: uuidMock, parameters: [], commit: 'replace' };
+    const info: TaskInfo = { name: 'notThere', uuid: uuidMock, value: [], commit: 'replace' };
 
     const task = await resolver.resolve(info);
 
@@ -22,7 +22,7 @@ describe('ModuleResolver', () => {
   it('should resolves a named exported function', async () => {
     const file = path.resolve(fixturesDirectory, 'export-named.js');
     const resolver = new ModuleResolver(file);
-    const info: TaskInfo = { name: 'taskA', uuid: uuidMock, parameters: [], commit: 'replace' };
+    const info: TaskInfo = { name: 'taskA', uuid: uuidMock, value: [], commit: 'replace' };
 
     const task = await resolver.resolve(info);
 
@@ -32,7 +32,7 @@ describe('ModuleResolver', () => {
   it('should resolves an default exported function', async () => {
     const file = path.resolve(fixturesDirectory, 'export-default.js');
     const resolver = new ModuleResolver(file);
-    const info: TaskInfo = { name: 'taskB', uuid: uuidMock, parameters: [], commit: 'replace' };
+    const info: TaskInfo = { name: 'taskB', uuid: uuidMock, value: [], commit: 'replace' };
 
     const task = await resolver.resolve(info);
 
@@ -43,7 +43,7 @@ describe('ModuleResolver', () => {
     const file = path.resolve(fixturesDirectory, 'export-default.js');
     const resolver = new ModuleResolver(file);
     const parameters = [{ life: 42 }, 'hello'];
-    const info: TaskInfo = { name: 'taskB', uuid: uuidMock, parameters, commit: 'replace' };
+    const info: TaskInfo = { name: 'taskB', uuid: uuidMock, value: parameters, commit: 'replace' };
 
     const task = await resolver.resolve(info);
 

--- a/packages/htms-js/tests/resolver.test.ts
+++ b/packages/htms-js/tests/resolver.test.ts
@@ -40,7 +40,7 @@ describe('createHtmsResolver', () => {
       uuid: 'uuid-test-0000-0000-mock',
       task: expect.any(Function),
       commit: 'replace',
-      parameters: [],
+      value: undefined,
     });
     expect(articlesTaskToken).toStrictEqual({
       type: 'task',
@@ -48,7 +48,7 @@ describe('createHtmsResolver', () => {
       uuid: 'uuid-test-0000-0001-mock',
       task: expect.any(Function),
       commit: 'replace',
-      parameters: [],
+      value: undefined,
     });
     await expect(newsTaskToken.task()).resolves.toBe('task done: getNews');
     await expect(articlesTaskToken.task()).resolves.toBe('task done: getArticles');

--- a/packages/htms-js/tests/serializer.test.ts
+++ b/packages/htms-js/tests/serializer.test.ts
@@ -216,6 +216,7 @@ describe('createHtmsSerializer', () => {
 
     const html = '<div data-htms="goodTask"/>\n<div data-htms="badTask"/>\n';
     const input = createStringStream(html);
+
     const resolver: Resolver = {
       resolve(info) {
         return () => {
@@ -242,6 +243,7 @@ describe('createHtmsSerializer', () => {
       }),
     );
 
+    // NOTE: token.value is stripped by JSON.stringify()
     expect(outputString).toMatchInlineSnapshot(`
       "<div data-htms="goodTask" data-htms-uuid="uuid-test-0000-0000-mock"/>
       <div data-htms="badTask" data-htms-uuid="uuid-test-0000-0001-mock"/>
@@ -254,8 +256,7 @@ describe('createHtmsSerializer', () => {
         "type": "task",
         "name": "badTask",
         "uuid": "uuid-test-0000-0001-mock",
-        "commit": "replace",
-        "parameters": []
+        "commit": "replace"
       }</pre>
       </div>
       </htms-chunk>
@@ -263,18 +264,18 @@ describe('createHtmsSerializer', () => {
     `);
   });
 
-  it('should serialize a simple html file with [data-htms] and [data-htms-params] attribute', async () => {
+  it('should serialize a simple html file with [data-htms] and [data-htms-value] attribute', async () => {
     mockRandomUUIDIncrement();
 
-    const html = `<div data-htms="goodTask" data-htms-params="{ life: 42, enabled: true }, 'hello'" />\n`;
+    const html = `<div data-htms="goodTask" data-htms-value="{ life: 42, enabled: true }" />\n`;
     const input = createStringStream(html);
-    const result: unknown[] = [];
+    let result: unknown;
     const resolver: Resolver = {
       resolve(info) {
-        return (...parameters) => {
-          result.push(parameters);
+        return (value) => {
+          result = value;
 
-          return Promise.resolve(`resolved task: ${info.name} with parameters: ${JSON.stringify(parameters)}`);
+          return Promise.resolve(`resolved task: ${info.name} with value: ${JSON.stringify(value)}`);
         };
       },
     };
@@ -286,18 +287,18 @@ describe('createHtmsSerializer', () => {
 
     const outputString = await collectString(output);
 
-    expect(result[0]).toStrictEqual([{ enabled: true, life: 42 }, 'hello']);
+    expect(result).toStrictEqual({ enabled: true, life: 42 });
     expect(outputString).toMatchInlineSnapshot(`
-      "<div data-htms="goodTask" data-htms-params="{ life: 42, enabled: true }, 'hello'" data-htms-uuid="uuid-test-0000-0000-mock"/>
-      <htms-chunk uuid="uuid-test-0000-0000-mock" commit="replace">resolved task: goodTask with parameters: [{"life":42,"enabled":true},"hello"]</htms-chunk>
+      "<div data-htms="goodTask" data-htms-value="{ life: 42, enabled: true }" data-htms-uuid="uuid-test-0000-0000-mock"/>
+      <htms-chunk uuid="uuid-test-0000-0000-mock" commit="replace">resolved task: goodTask with value: {"life":42,"enabled":true}</htms-chunk>
       "
     `);
   });
 
-  it('should throws an error if [data-htms-params] is not a valid JSON value', async () => {
+  it('should throws an error if [data-htms-value] is not a valid JSON value', async () => {
     mockRandomUUIDIncrement();
 
-    const html = `<div data-htms="badTask" data-htms-params="1 + 1" />\n`;
+    const html = `<div data-htms="badTask" data-htms-value="1 + 1" />\n`;
     const input = createStringStream(html);
     const resolver: Resolver = {
       resolve(info) {
@@ -313,7 +314,7 @@ describe('createHtmsSerializer', () => {
       .pipeThrough(createHtmsSerializer());
 
     await expect(collectString(output)).rejects.toThrowError(
-      "Failed to parse [data-htms-params] at [1:1]: SyntaxError: JSON5: invalid character '+' at 1:4",
+      "Failed to parse [data-htms-value] at [1:1]: SyntaxError: JSON5: invalid character '+' at 1:3",
     );
   });
 
@@ -322,10 +323,13 @@ describe('createHtmsSerializer', () => {
 
     const html = `<div data-htms="goodTask" data-htms-commit="content" />\n`;
     const input = createStringStream(html);
+    let result: unknown;
     const resolver: Resolver = {
       resolve(info) {
-        return (...parameters) => {
-          return Promise.resolve(`resolved task: ${info.name} with parameters: ${JSON.stringify(parameters)}`);
+        return (value) => {
+          result = value;
+
+          return Promise.resolve(`resolved task: ${info.name} with value: ${JSON.stringify(value)}`);
         };
       },
     };
@@ -337,9 +341,10 @@ describe('createHtmsSerializer', () => {
 
     const outputString = await collectString(output);
 
+    expect(result).toBeUndefined();
     expect(outputString).toMatchInlineSnapshot(`
       "<div data-htms="goodTask" data-htms-commit="content" data-htms-uuid="uuid-test-0000-0000-mock" role="status" aria-busy="true"/>
-      <htms-chunk uuid="uuid-test-0000-0000-mock" commit="content">resolved task: goodTask with parameters: []</htms-chunk>
+      <htms-chunk uuid="uuid-test-0000-0000-mock" commit="content">resolved task: goodTask with value: undefined</htms-chunk>
       "
     `);
   });

--- a/packages/htms-js/tests/tokenizer.test.ts
+++ b/packages/htms-js/tests/tokenizer.test.ts
@@ -86,11 +86,11 @@ describe('createHtmsTokenizer', () => {
     });
   });
 
-  it('should tokenize a simple html string with [data-htms] and [data-htms-params] attribute (single value)', async () => {
+  it('should tokenize a simple html string with [data-htms] and [data-htms-value] attribute (single value)', async () => {
     const uuidMock = 'uuid-test-0000-0000-mock';
     mockRandomUUIDOnce(uuidMock);
 
-    const startTag = `<div data-htms="taskNameTest" data-htms-params="{ life: 42, enabled: true }, 'hello'">`;
+    const startTag = `<div data-htms="taskNameTest" data-htms-value="{ life: 42, enabled: true }">`;
     const html = `${startTag}...</div>`;
     const input = createStringStream(html);
 
@@ -105,16 +105,16 @@ describe('createHtmsTokenizer', () => {
       taskInfo: {
         uuid: uuidMock,
         name: 'taskNameTest',
-        parameters: [{ life: 42 }, 'hello'],
+        value: { life: 42, enabled: true },
       },
     });
   });
 
-  it('should tokenize a simple html string with [data-htms] and [data-htms-params] attribute (array)', async () => {
+  it('should tokenize a simple html string with [data-htms] and [data-htms-value] attribute (array)', async () => {
     const uuidMock = 'uuid-test-0000-0000-mock';
     mockRandomUUIDOnce(uuidMock);
 
-    const startTag = `<div data-htms="taskNameTest" data-htms-params="[42, true, 'hello', { life: 42 }]">`;
+    const startTag = `<div data-htms="taskNameTest" data-htms-value="[42, true, 'hello', { life: 42 }]">`;
     const html = `${startTag}...</div>`;
     const input = createStringStream(html);
 
@@ -129,7 +129,7 @@ describe('createHtmsTokenizer', () => {
       taskInfo: {
         uuid: uuidMock,
         name: 'taskNameTest',
-        parameters: [42, true, 'hello', { life: 42 }],
+        value: [42, true, 'hello', { life: 42 }],
       },
     });
   });

--- a/packages/htms-server/readme.md
+++ b/packages/htms-server/readme.md
@@ -115,48 +115,60 @@ HTMS supports scoped modules, meaning tasks can resolve from different modules d
 
 This makes it easier to compose and reuse modules without conflicts.
 
-## Task parameters (`data-htms-args`)
+## Task value (`data-htms-value`)
 
-Pass parameters to tasks via a JSON/JSON5 array stored in the `data-htms-args` attribute.
+`data-htms-value` passes **one argument** to the task.
+When present, the value is parsed as **JSON5** and given to the task as its **first parameter**.
+If the attribute is **omitted**, the task receives `undefined`.
 
-- Accepts either a **JSON/JSON5 array** (recommended) or a **comma-separated list** without brackets.
-- You can also pass a **single value**; it is treated as the first argument (equivalent to wrapping it in `[...]`).
-- Supports: single or double quotes, unquoted object keys, trailing commas, comments.
-- **Not supported:** `undefined`, functions, arbitrary JS expressions. Use `null` when you need to indicate “no value.”
+- Accepted: `undefined`, `null`, booleans, numbers, strings, arrays, objects (JSON5: single quotes, unquoted keys, comments, trailing commas).
+- Not accepted: functions, arbitrary JS expressions.
+- Need multiple pieces of data? Pack them into **one** object or array.
 
-**HTML examples**
+### HTML examples
 
 ```html
-<!-- JSON/JSON5 array -->
-<div data-htms="renderUserCard" data-htms-args='[12345, "en-GB", { showBadges: true, theme: "compact" }]' />
+<!-- attribute omitted → value = undefined -->
+<div data-htms="loadDefaults"></div>
 
-<!-- Comma-separated list (equivalent to an array) -->
-<div data-htms="renderFeed" data-htms-args="12345, { limit: 10, cursor: null }" />
+<!-- primitive values -->
+<div data-htms="loadDefaults" data-htms-value="null"></div>
+<div data-htms="loadProfile" data-htms-value="true"></div>
+<div data-htms="loadUser" data-htms-value="12345"></div>
+<div data-htms="loadByName" data-htms-value="'john-doe'"></div>
 
-<!-- Single value (first argument only) -->
-<div data-htms="loadProfile" data-htms-args="12345" />
+<!-- object / array (JSON5) -->
+<div data-htms="loadFeed" data-htms-value="{ theme: 'compact', limit: 10 }"></div>
+<div data-htms="renderOffer" data-htms-value="[42, { theme: 'compact' }]"></div>
 ```
 
-**Task examples**
+### Task signatures (TypeScript examples)
 
-```js
-// page-module.js
-export async function renderUserCard(userId, locale, opts) {
-  // userId === 12345
-  // locale === "en-GB"
-  // opts === { showBadges: true, theme: "compact" }
-  return `<div class="user-card">User #${userId}</div>`;
+```ts
+export async function loadDefaults(value: undefined | null) {}
+export async function loadProfile(value: boolean) {}
+export async function loadUser(value: number) {}
+export async function loadByName(value: string) {}
+
+export async function loadFeed(value: { theme: string; limit: number }) {
+  // value.theme === 'compact'
+  // value.limit === 10
 }
 
-export async function renderFeed(userId, page) {
-  // page === { limit: 10, cursor: null }
-  return `<ul class="feed">...</ul>`;
-}
-
-export async function loadProfile(userId) {
-  return `<div class="profile">Profile of ${userId}</div>`;
+export async function renderOffer(value: [number, { theme: string }]) {
+  const [offerId, options] = value;
+  // offerId === 42
+  // options.theme === 'compact'
 }
 ```
+
+### Tips
+
+- **Keep it serializable.** Only data you could express in JSON5 should go here.
+- **Prefer objects** when the meaning of fields matters: `{ id, page, sort }` is clearer than `[id, page, sort]`.
+- **Strings must be quoted.** Use JSON5 single quotes in HTML to stay readable.
+- **Validate inside the task.** Treat the value as untrusted input.
+- **One argument by design.** If you need several inputs, bundle them: `(value)` where `value` is an object/array.
 
 ## Commit behavior (`data-htms-commit`)
 


### PR DESCRIPTION
BREAKING CHANGE:  task now receives a single `value`
- remove `data-htms-params`
- use `data-htms-value` in HTML
- task signatures change from (...params) → (value).


## Task value (`data-htms-value`)

`data-htms-value` passes **one argument** to the task.
When present, the value is parsed as **JSON5** and given to the task as its **first parameter**.
If the attribute is **omitted**, the task receives `undefined`.

- Accepted: `undefined`, `null`, booleans, numbers, strings, arrays, objects (JSON5: single quotes, unquoted keys, comments, trailing commas).
- Not accepted: functions, arbitrary JS expressions.
- Need multiple pieces of data? Pack them into **one** object or array.

### HTML examples

```html
<!-- attribute omitted → value = undefined -->
<div data-htms="loadDefaults"></div>

<!-- primitive values -->
<div data-htms="loadDefaults" data-htms-value="null"></div>
<div data-htms="loadProfile" data-htms-value="true"></div>
<div data-htms="loadUser" data-htms-value="12345"></div>
<div data-htms="loadByName" data-htms-value="'john-doe'"></div>

<!-- object / array (JSON5) -->
<div data-htms="loadFeed" data-htms-value="{ theme: 'compact', limit: 10 }"></div>
<div data-htms="renderOffer" data-htms-value="[42, { theme: 'compact' }]"></div>
```

### Task signatures (TypeScript examples)

```ts
export async function loadDefaults(value: undefined | null) {}
export async function loadProfile(value: boolean) {}
export async function loadUser(value: number) {}
export async function loadByName(value: string) {}

export async function loadFeed(value: { theme: string; limit: number }) {
  // value.theme === 'compact'
  // value.limit === 10
}

export async function renderOffer(value: [number, { theme: string }]) {
  const [offerId, options] = value;
  // offerId === 42
  // options.theme === 'compact'
}
```

### Tips

- **Keep it serializable.** Only data you could express in JSON5 should go here.
- **Prefer objects** when the meaning of fields matters: `{ id, page, sort }` is clearer than `[id, page, sort]`.
- **Strings must be quoted.** Use JSON5 single quotes in HTML to stay readable.
- **Validate inside the task.** Treat the value as untrusted input.
- **One argument by design.** If you need several inputs, bundle them: `(value)` where `value` is an object/array.