### PR TITLE
feat: task API `commit`

### DIFF
--- a/packages/htms-js/readme.md
+++ b/packages/htms-js/readme.md
@@ -101,7 +101,7 @@ Visit `http://localhost:3000`: content renders immediately, then fills itself in
 
 When you call `createHtmsFileModulePipeline('./home-page.html')`, HTMS will automatically look for a sibling module file named `./home-page.js` and resolve tasks from there. If you want to:
 
-- **Mix several modules on the same page** → see [Scoped modules](#scoped-modules).
+- **Mix several modules on the same page** → see [Scoped modules](#scoped-modules-data-htms-module).
 - **Point to another file** → use the `specifier` option in the [API](#api).
 - **Provide your own logic** → see [Custom resolvers](#custom-resolvers).
 
@@ -205,14 +205,14 @@ export async function renderOffer(value: [number, { theme: string }]) {
 
 Controls how the streamed result is applied to the placeholder. Default: `replace`.
 
-| Value     | Effect                                              | DOM equivalent               |
-| --------- | --------------------------------------------------- | ---------------------------- |
-| `replace` | Replace the **placeholder node** (outer)            | `host.replaceWith(frag)`     |
-| `content` | Replace the **children** of the placeholder (inner) | `host.replaceChildren(frag)` |
-| `append`  | Append result **as last child**                     | `host.append(frag)`          |
-| `prepend` | Insert result **as first child**                    | `host.prepend(frag)`         |
-| `before`  | Insert result **before** the placeholder            | `host.before(frag)`          |
-| `after`   | Insert result **after** the placeholder             | `host.after(frag)`           |
+| Value     | Effect                                              | DOM equivalent               | Accessibility (`aria-busy`) |
+| --------- | --------------------------------------------------- | ---------------------------- | --------------------------- |
+| `replace` | Replace the **placeholder node** (outer)            | `host.replaceWith(frag)`     | No                          |
+| `content` | Replace the **children** of the placeholder (inner) | `host.replaceChildren(frag)` | Yes                         |
+| `append`  | Append result **as last child**                     | `host.append(frag)`          | Yes                         |
+| `prepend` | Insert result **as first child**                    | `host.prepend(frag)`         | Yes                         |
+| `before`  | Insert result **before** the placeholder            | `host.before(frag)`          | No                          |
+| `after`   | Insert result **after** the placeholder             | `host.after(frag)`           | No                          |
 
 **HTML examples**
 
@@ -260,17 +260,84 @@ Assuming the streamed content is: `<div>Streamed</div>`
 
 **Notes**
 
-- With `append`, `prepend`, `before`, `after`, the placeholder stays in the DOM. Remove or restyle it if needed once the chunk is committed.
-- With `content`, you keep the container (useful for accessibility/live regions).
+- With `append`, `prepend`, `before`, `after`, the placeholder stays in the DOM.
+- With `content`, `append`, or `prepend`, the container is kept (useful for accessibility/live regions).
 
-### Accessibility (content mode)
+### Accessibility (`content`, `append`, `prepend` modes)
 
-When `data-htms-commit="content"` is used, HTMS automatically marks the placeholder as a **polite live region** while it is pending:
+When `data-htms-commit="content"`, `append`, or `prepend` is used, HTMS automatically marks the placeholder as a **polite live region** while it is pending:
 
 - Adds `role="status"` and `aria-busy="true"` on the host before the first update.
-- On commit, flips `aria-busy` to `false` so screen readers announce the final content once.
+- On the first update, sets `aria-busy="false"`, so screen readers announce the content as soon as it arrives.
+- Screen readers will announce any further chunks (additional updates) directly, since `aria-busy` stays `false`.
 
-This gives you accessible announcements out of the box, without extra markup. If you need a different behavior, switch to another commit mode or set your own ARIA attributes on the host.
+This gives you accessible announcements out of the box, without extra markup.
+
+**Tips for accessibility:**
+
+- If accessibility is a priority, avoid too many updates: prefer a single update ("one shot") if the task is fast enough to prevent excessive announcements.
+
+---
+
+## Task API: `api.commit(...)`
+
+Use `api.commit(mode, html)` inside a task to push partial updates before the final return.
+
+Minimal shape (JS):
+
+```js
+// In a task: (value, api) => Promise<string>
+api.commit(mode, html); // mode: 'content' | 'append' | 'prepend' | 'before' | 'after'
+```
+
+Type definitions (TypeScript):
+
+```ts
+export type Commit = 'replace' | 'content' | 'append' | 'prepend' | 'before' | 'after';
+
+export interface TaskApi {
+  // 'replace' is reserved for the final return; partial commits use the other modes
+  commit(mode: Exclude<Commit, 'replace'>, html: string): void;
+}
+
+export type Task<Value = unknown> = (value: Value, api: TaskApi) => PromiseLike<string>;
+```
+
+Rules:
+
+- Allowed modes: `content`, `append`, `prepend`, `before`, `after` (not `replace`).
+- Each `api.commit(...)` emits a partial chunk applied immediately on the client.
+- The final HTML is the task’s return value and uses the host’s `data-htms-commit`. With `data-htms-commit="append"`, returning `''` performs no DOM change (just cleanup).
+
+Example (stream items with `append`):
+
+```html
+<!-- Host is the final container; we append <li> items into it -->
+<ul data-htms="loadFeed" data-htms-commit="append">
+  <li>Loading…</li>
+</ul>
+```
+
+```js
+// tasks.js
+export async function loadFeed(_value, api) {
+  // Clear the placeholder once (optional if already empty)
+  api.commit('content', '');
+
+  // Any async iterable of items
+  for await (const item of getFeedAsyncIterable()) {
+    api.commit('append', `<li>${item.title}</li>`);
+  }
+
+  // Final empty return with host commit="append" → no DOM change, just cleanup
+  return '';
+}
+```
+
+Notes:
+
+- Fragments must be well‑formed HTML. Use the host as the container; don’t stream unbalanced tags.
+- `content`, `append`, and `prepend` automatically manage live-region ARIA. If you need announcements, use these modes.
 
 ---
 

--- a/packages/htms-js/src/browser/api.js
+++ b/packages/htms-js/src/browser/api.js
@@ -6,6 +6,7 @@
       connectedCallback() {
         const uuid = this.getAttribute('uuid');
         const commitMode = this.getAttribute('commit');
+        const partial = this.getAttribute('partial');
 
         if (!uuid) {
           console.warn("[htms-chunk] missing 'uuid' attribute:", this);
@@ -22,7 +23,11 @@
 
         requestAnimationFrame(() => {
           commit(host, this.innerHTML, commitMode);
-          removeHtmsAttributes(host);
+
+          if (typeof partial !== 'string' || partial.trim() === 'false') {
+            removeHtmsAttributes(host);
+          }
+
           this.remove();
         });
       }
@@ -56,10 +61,12 @@
       }
       case 'append': {
         host.append(fragment);
+        host.setAttribute('aria-busy', 'false');
         break;
       }
       case 'prepend': {
         host.prepend(fragment);
+        host.setAttribute('aria-busy', 'false');
         break;
       }
       case 'before': {

--- a/packages/htms-js/src/stream/resolver.ts
+++ b/packages/htms-js/src/stream/resolver.ts
@@ -1,8 +1,16 @@
 import { TransformStream } from 'node:stream/web';
 
-import type { TaskInfo, Token } from './tokenizer.js';
+import type { Commit, TaskInfo, Token } from './tokenizer.js';
 
-export type Task<Value = unknown> = (value?: Value) => PromiseLike<string>;
+export interface TaskApiOptions {
+  mode?: Exclude<Commit, 'replace'>;
+}
+
+export interface TaskApi {
+  commit(html: string, options?: TaskApiOptions): void;
+}
+
+export type Task<Value = unknown> = (value: Value, api: TaskApi) => PromiseLike<string>;
 
 export interface TaskToken extends TaskInfo {
   type: 'task';

--- a/packages/htms-js/src/stream/serializer.ts
+++ b/packages/htms-js/src/stream/serializer.ts
@@ -3,21 +3,28 @@ import { TransformStream } from 'node:stream/web';
 import { escapeAttribute } from 'entities/escape';
 
 import { getApiSource } from '../browser/index.js';
-import type { ResolverToken, TaskToken } from './resolver.js';
-import type { EndToken, StartTag, StartToken } from './tokenizer.js';
+import type { ResolverToken, TaskApi, TaskToken } from './resolver.js';
+import type { Commit, EndToken, StartTag, StartToken } from './tokenizer.js';
 
 const browserApiSource = getApiSource();
 
-function formatStartTag(token: StartTag): string {
-  let output = `<${token.tagName}`;
+interface Attribute {
+  name: string;
+  value?: string;
+}
 
-  for (const attribute of token.attrs) {
-    output += ` ${attribute.name}="${escapeAttribute(attribute.value)}"`;
+function formatAttributes(attributes: Attribute[]): string {
+  let output = '';
+
+  for (const attribute of attributes) {
+    output += attribute.value ? ` ${attribute.name}="${escapeAttribute(attribute.value)}"` : ` ${attribute.name}"`;
   }
 
-  output += token.selfClosing ? '/>' : '>';
-
   return output;
+}
+
+function formatStartTag(token: StartTag): string {
+  return `<${token.tagName}${formatAttributes(token.attrs)}${token.selfClosing ? '/>' : '>'}`;
 }
 
 type Controller = TransformStreamDefaultController<string>;
@@ -47,11 +54,39 @@ function processEndTag(token: EndToken, controller: Controller): void {
   controller.enqueue(token.html);
 }
 
+interface CommitSettings {
+  mode: Commit;
+  token: TaskToken;
+  controller: Controller;
+  partial: boolean;
+  html: string;
+}
+
+function commit(settings: CommitSettings): void {
+  const attributes: Attribute[] = [
+    { name: 'uuid', value: settings.token.uuid },
+    { name: 'commit', value: settings.mode },
+  ];
+
+  if (settings.partial) {
+    attributes.push({ name: 'partial', value: 'true' });
+  }
+
+  settings.controller.enqueue(`<htms-chunk${formatAttributes(attributes)}>${settings.html}</htms-chunk>\n`);
+}
+
+function createApi(token: TaskToken, controller: Controller): TaskApi {
+  return {
+    commit: (html, options) =>
+      commit({ token, controller, html, mode: options?.mode ?? 'append', ...options, partial: true }),
+  };
+}
+
 async function runTask(token: TaskToken, controller: Controller, debug: boolean): Promise<void> {
   try {
-    const output = await token.task(token.value);
+    const api = createApi(token, controller);
 
-    controller.enqueue(`<htms-chunk uuid="${token.uuid}" commit="${token.commit}">${output}</htms-chunk>\n`);
+    commit({ token, controller, mode: token.commit, html: await token.task(token.value, api), partial: false });
   } catch (error_) {
     const title = 'Unhandled Task Error';
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
@@ -92,6 +127,8 @@ export interface HtmsSerializerOptions {
   debug?: boolean | undefined;
 }
 
+const busyStatus = new Set(['content', 'append', 'prepend']);
+
 export function createHtmsSerializer(options?: HtmsSerializerOptions | undefined): SerializerStream {
   const { debug = false } = options ?? {};
   const seenEndTags = new Set<string>();
@@ -115,7 +152,7 @@ export function createHtmsSerializer(options?: HtmsSerializerOptions | undefined
           removeHtmsAttribute(token, 'module');
           setHtmsAttribute(token, 'uuid', token.taskInfo.uuid);
 
-          if (token.taskInfo.commit === 'content') {
+          if (busyStatus.has(token.taskInfo.commit)) {
             setAttribute(token, 'role', 'status');
             setAttribute(token, 'aria-busy', 'true');
           }

--- a/packages/htms-js/tests/browser-api.test.ts
+++ b/packages/htms-js/tests/browser-api.test.ts
@@ -17,9 +17,18 @@ function createHost(uuid: string, html = ''): void {
 
 function createChunk(uuid: string, commit: Commit): void {
   const chunk = document.createElement('htms-chunk');
-  chunk.setAttribute('commit', commit);
   chunk.setAttribute('uuid', uuid);
+  chunk.setAttribute('commit', commit);
   chunk.innerHTML = '<span>contents...</span>';
+  document.body.append(chunk);
+}
+
+function createPartialChunk(uuid: string, commit: Commit, html: string): void {
+  const chunk = document.createElement('htms-chunk');
+  chunk.setAttribute('uuid', uuid);
+  chunk.setAttribute('commit', commit);
+  chunk.setAttribute('partial', '');
+  chunk.innerHTML = `\n${html}`;
   document.body.append(chunk);
 }
 
@@ -94,7 +103,7 @@ describe('<htms-chunk> with commit', () => {
     createChunk(uuid, 'append');
 
     expect(document.body.innerHTML).toMatchInlineSnapshot(
-      `"<div class="host"><h2>title</h2><span>contents...</span></div>"`,
+      `"<div class="host" aria-busy="false"><h2>title</h2><span>contents...</span></div>"`,
     );
   });
 
@@ -105,7 +114,7 @@ describe('<htms-chunk> with commit', () => {
     createChunk(uuid, 'prepend');
 
     expect(document.body.innerHTML).toMatchInlineSnapshot(
-      `"<div class="host"><span>contents...</span><h2>title</h2></div>"`,
+      `"<div class="host" aria-busy="false"><span>contents...</span><h2>title</h2></div>"`,
     );
   });
 
@@ -128,6 +137,40 @@ describe('<htms-chunk> with commit', () => {
 
     expect(document.body.innerHTML).toMatchInlineSnapshot(
       `"<div class="host"><h2>title</h2></div><span>contents...</span>"`,
+    );
+  });
+});
+
+describe('<htms-chunk> with partial commit', () => {
+  it('should appends partial chunk to the host', async () => {
+    const uuid = 'uuid-test-0000-0000-mock';
+
+    createHost(uuid, '\n<h2>host-title</h2>');
+    createPartialChunk(uuid, 'prepend', '<h1>chunk-1</h1>');
+    createPartialChunk(uuid, 'append', '<article>chunk-2</article>');
+    createPartialChunk(uuid, 'append', '<article>chunk-3</article>');
+
+    expect(document.body.innerHTML).toMatchInlineSnapshot(
+      `
+      "<div class="host" data-htms-uuid="uuid-test-0000-0000-mock" aria-busy="false">
+      <h1>chunk-1</h1>
+      <h2>host-title</h2>
+      <article>chunk-2</article>
+      <article>chunk-3</article></div>"
+    `,
+    );
+
+    // should insert the last chunk after host and remove [data-htms-uuid] attribute on it
+    createChunk(uuid, 'after');
+
+    expect(document.body.innerHTML).toMatchInlineSnapshot(
+      `
+      "<div class="host" aria-busy="false">
+      <h1>chunk-1</h1>
+      <h2>host-title</h2>
+      <article>chunk-2</article>
+      <article>chunk-3</article></div><span>contents...</span>"
+    `,
     );
   });
 });

--- a/packages/htms-js/tests/module-resolver.test.ts
+++ b/packages/htms-js/tests/module-resolver.test.ts
@@ -1,12 +1,14 @@
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { ModuleResolver, type TaskInfo } from '../src/index.js';
 
 const fixturesDirectory = path.resolve(import.meta.dirname, 'fixtures', 'tasks');
 
 const uuidMock = 'uuid-test-0000-0000-mock';
+
+const apiMock = { commit: vi.fn() };
 
 describe('ModuleResolver', () => {
   it('should rejects task when the function is missing', async () => {
@@ -16,7 +18,7 @@ describe('ModuleResolver', () => {
 
     const task = await resolver.resolve(info);
 
-    await expect(task()).rejects.toThrow(`Task function 'notThere' not found in '${file}'`);
+    await expect(task(info.value, apiMock)).rejects.toThrow(`Task function 'notThere' not found in '${file}'`);
   });
 
   it('should resolves a named exported function', async () => {
@@ -26,7 +28,7 @@ describe('ModuleResolver', () => {
 
     const task = await resolver.resolve(info);
 
-    await expect(task()).resolves.toBe('named exported task A completed: undefined');
+    await expect(task(info.value, apiMock)).resolves.toBe('named exported task A completed: undefined');
   });
 
   it('should resolves an default exported function', async () => {
@@ -36,7 +38,7 @@ describe('ModuleResolver', () => {
 
     const task = await resolver.resolve(info);
 
-    await expect(task()).resolves.toBe('default exported task B completed: undefined');
+    await expect(task(info.value, apiMock)).resolves.toBe('default exported task B completed: undefined');
   });
 
   it('should pass parameters to task', async () => {
@@ -47,6 +49,6 @@ describe('ModuleResolver', () => {
 
     const task = await resolver.resolve(info);
 
-    await expect(task(value)).resolves.toBe('default exported task B completed: [{"life":42},"hello"]');
+    await expect(task(value, apiMock)).resolves.toBe('default exported task B completed: [{"life":42},"hello"]');
   });
 });

--- a/packages/htms-js/tests/resolver.test.ts
+++ b/packages/htms-js/tests/resolver.test.ts
@@ -2,7 +2,7 @@ import './fixtures/crypto.mock.js';
 
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   createFileStream,
@@ -15,6 +15,8 @@ import { mockRandomUUIDIncrement, mockRandomUUIDOnce } from './fixtures/crypto.m
 import { collect } from './fixtures/stream.helpers.js';
 
 const simpleHtmlFixture = path.resolve(import.meta.dirname, './fixtures/html/simple.html');
+
+const apiMock = { commit: vi.fn() };
 
 describe('createHtmsResolver', () => {
   it('should resolve tasks and sort tasks at the end of the stream', async () => {
@@ -50,8 +52,8 @@ describe('createHtmsResolver', () => {
       commit: 'replace',
       value: undefined,
     });
-    await expect(newsTaskToken.task()).resolves.toBe('task done: getNews');
-    await expect(articlesTaskToken.task()).resolves.toBe('task done: getArticles');
+    await expect(newsTaskToken.task(newsTaskToken.value, apiMock)).resolves.toBe('task done: getNews');
+    await expect(articlesTaskToken.task(articlesTaskToken.value, apiMock)).resolves.toBe('task done: getArticles');
   });
 
   it('should throw error when the task throw an error', async () => {
@@ -73,7 +75,9 @@ describe('createHtmsResolver', () => {
 
     expect(tokens).toHaveLength(54);
 
-    await expect(articlesTaskToken.task()).rejects.toThrowError('task error: getArticles');
+    await expect(articlesTaskToken.task(articlesTaskToken.value, apiMock)).rejects.toThrowError(
+      'task error: getArticles',
+    );
   });
 
   it('should throw error when the resolved task is not a function', async () => {

--- a/packages/htms-js/tests/serializer.test.ts
+++ b/packages/htms-js/tests/serializer.test.ts
@@ -48,6 +48,7 @@ describe('createHtmsSerializer', () => {
             connectedCallback() {
               const uuid = this.getAttribute('uuid');
               const commitMode = this.getAttribute('commit');
+              const partial = this.getAttribute('partial');
 
               if (!uuid) {
                 console.warn("[htms-chunk] missing 'uuid' attribute:", this);
@@ -64,7 +65,11 @@ describe('createHtmsSerializer', () => {
 
               requestAnimationFrame(() => {
                 commit(host, this.innerHTML, commitMode);
-                removeHtmsAttributes(host);
+
+                if (typeof partial !== 'string' || partial.trim() === 'false') {
+                  removeHtmsAttributes(host);
+                }
+
                 this.remove();
               });
             }
@@ -98,10 +103,12 @@ describe('createHtmsSerializer', () => {
             }
             case 'append': {
               host.append(fragment);
+              host.setAttribute('aria-busy', 'false');
               break;
             }
             case 'prepend': {
               host.prepend(fragment);
+              host.setAttribute('aria-busy', 'false');
               break;
             }
             case 'before': {
@@ -345,6 +352,40 @@ describe('createHtmsSerializer', () => {
     expect(outputString).toMatchInlineSnapshot(`
       "<div data-htms="goodTask" data-htms-commit="content" data-htms-uuid="uuid-test-0000-0000-mock" role="status" aria-busy="true"/>
       <htms-chunk uuid="uuid-test-0000-0000-mock" commit="content">resolved task: goodTask with value: undefined</htms-chunk>
+      "
+    `);
+  });
+
+  it('should commit partial chunks', async () => {
+    mockRandomUUIDIncrement();
+
+    const html = `<div data-htms="partialTask" />\n`;
+    const input = createStringStream(html);
+    const resolver: Resolver = {
+      resolve(info) {
+        return (value, api) => {
+          api.commit('<div>First partial chunk</div>', { mode: 'before' });
+          api.commit('<div>Second partial chunk</div>');
+          api.commit('<div>Third partial chunk</div>', { mode: 'after' });
+
+          return Promise.resolve(`resolved task: ${info.name} with parameters: ${JSON.stringify(value)}`);
+        };
+      },
+    };
+
+    const output = input
+      .pipeThrough(createHtmsTokenizer())
+      .pipeThrough(createHtmsResolver(resolver))
+      .pipeThrough(createHtmsSerializer());
+
+    const outputString = await collectString(output);
+
+    expect(outputString).toMatchInlineSnapshot(`
+      "<div data-htms="partialTask" data-htms-uuid="uuid-test-0000-0000-mock"/>
+      <htms-chunk uuid="uuid-test-0000-0000-mock" commit="before" partial="true"><div>First partial chunk</div></htms-chunk>
+      <htms-chunk uuid="uuid-test-0000-0000-mock" commit="append" partial="true"><div>Second partial chunk</div></htms-chunk>
+      <htms-chunk uuid="uuid-test-0000-0000-mock" commit="after" partial="true"><div>Third partial chunk</div></htms-chunk>
+      <htms-chunk uuid="uuid-test-0000-0000-mock" commit="replace">resolved task: partialTask with parameters: undefined</htms-chunk>
       "
     `);
   });


### PR DESCRIPTION
## Task API: `api.commit(...)`

Use `api.commit(mode, html)` inside a task to push partial updates before the final return.

Minimal shape (JS):

```js
// In a task: (value, api) => Promise<string>
api.commit(mode, html); // mode: 'content' | 'append' | 'prepend' | 'before' | 'after'
```

Type definitions (TypeScript):

```ts
export type Commit = 'replace' | 'content' | 'append' | 'prepend' | 'before' | 'after';

export interface TaskApi {
  // 'replace' is reserved for the final return; partial commits use the other modes
  commit(mode: Exclude<Commit, 'replace'>, html: string): void;
}

export type Task<Value = unknown> = (value: Value, api: TaskApi) => PromiseLike<string>;
```

Rules:

- Allowed modes: `content`, `append`, `prepend`, `before`, `after` (not `replace`).
- Each `api.commit(...)` emits a partial chunk applied immediately on the client.
- The final HTML is the task’s return value and uses the host’s `data-htms-commit`. With `data-htms-commit="append"`, returning `''` performs no DOM change (just cleanup).

Example (stream items with `append`):

```html
<!-- Host is the final container; we append <li> items into it -->
<ul data-htms="loadFeed" data-htms-commit="append">
  <li>Loading…</li>
</ul>
```

```js
// tasks.js
export async function loadFeed(_value, api) {
  // Clear the placeholder once (optional if already empty)
  api.commit('content', '');

  // Any async iterable of items
  for await (const item of getFeedAsyncIterable()) {
    api.commit('append', `<li>${item.title}</li>`);
  }

  // Final empty return with host commit="append" → no DOM change, just cleanup
  return '';
}
```

Notes:

- Fragments must be well‑formed HTML. Use the host as the container; don’t stream unbalanced tags.
- `content`, `append`, and `prepend` automatically manage live-region ARIA. If you need announcements, use these modes.